### PR TITLE
Change rawsockets to nativesockets.

### DIFF
--- a/src/irc.nim
+++ b/src/irc.nim
@@ -31,7 +31,7 @@ include "system/inclrtl"
 
 import net, strutils, strtabs, parseutils, times, asyncdispatch, asyncnet
 import os, tables, deques
-from rawsockets import Port
+from nativesockets import Port
 export `[]`
 
 type


### PR DESCRIPTION
The rest of the code seems to work fine as far as I can tell, but (recent?) changes have renamed `rawsockets` to `nativesockets`.

This simple naming fix should bring this library back up-to-date.