### PR TITLE
Fix a handful of issues.

### DIFF
--- a/irc.nimble
+++ b/irc.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version = "0.2.0"
+version = "0.2.1"
 author = "Dominik Picheta"
 description = "IRC client module"
 license = "MIT"

--- a/src/irc.nim
+++ b/src/irc.nim
@@ -355,6 +355,10 @@ proc processLine(irc: Irc | AsyncIrc, line: string): IrcEvent =
     result.typ = EvDisconnected
   else:
     result = parseMessage(line)
+    
+    if result.params.len == 0:
+      result.params = @[""]
+    
     # Get the origin
     result.origin = result.params[0]
     if result.origin == irc.nick and

--- a/src/irc.nim
+++ b/src/irc.nim
@@ -356,9 +356,6 @@ proc processLine(irc: Irc | AsyncIrc, line: string): IrcEvent =
   else:
     result = parseMessage(line)
     
-    if result.params.len == 0:
-      result.params = @[""]
-    
     # Get the origin
     result.origin = result.params[0]
     if result.origin == irc.nick and

--- a/src/irc.nim
+++ b/src/irc.nim
@@ -446,7 +446,7 @@ proc processOther(irc: Irc, ev: var IrcEvent): bool =
 
   if epochTime() - irc.lastPong >= 120.0 and irc.lastPong != -1.0:
     irc.close()
-    ev.typ = EvTimeout
+    ev = IrcEvent(typ: EvTimeout)
     return true
 
   for i in 0..irc.messageBuffer.len-1:
@@ -468,7 +468,7 @@ proc processOtherForever(irc: AsyncIrc) {.async.} =
     if epochTime() - irc.lastPong >= 120.0 and irc.lastPong != -1.0:
       irc.close()
       var ev: IrcEvent
-      ev.typ = EvTimeout
+      ev = IrcEvent(typ: EvTimeout)
       asyncCheck irc.handleEvent(irc, ev)
 
     for i in 0..irc.messageBuffer.len-1:
@@ -498,7 +498,7 @@ proc poll*(irc: Irc, ev: var IrcEvent,
 
   if not (irc.status == SockConnected):
     # Do not close the socket here, it is already closed!
-    ev.typ = EvDisconnected
+    ev = IrcEvent(typ: EvDisconnected)
   var line = TaintedString""
   try:
     irc.sock.readLine(line, timeout)


### PR DESCRIPTION
- #11 is fixed; all discriminant changes are replaced with fresh initialization to `EvTimeout` or `EvDisconnected`.
- A crash where `result.params` would occasionally be empty somehow is fixed; I've had this crash my bot on startup a couple of times.