### PR TITLE
Fix more object discriminant issues.

### DIFF
--- a/irc.nimble
+++ b/irc.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version = "0.2.1"
+version = "0.2.2"
 author = "Dominik Picheta"
 description = "IRC client module"
 license = "MIT"

--- a/src/irc.nim
+++ b/src/irc.nim
@@ -207,11 +207,11 @@ proc isNumber(s: string): bool =
   result = i == s.len and s.len > 0
 
 proc parseMessage(msg: string): IrcEvent =
-  result.typ       = EvMsg
-  result.cmd       = MUnknown
-  result.tags      = newStringTable()  
-  result.raw       = msg
-  result.timestamp = times.getTime()
+  result = IrcEvent(typ:       EvMsg,
+                    cmd:       MUnknown,
+                    tags:      newStringTable(),
+                    raw:       msg,
+                    timestamp: times.getTime())
   var i = 0
   # Process the tags
   if msg[i] == '@':
@@ -352,7 +352,7 @@ proc addNick(irc: Irc | AsyncIrc, chan, nick: string) =
 proc processLine(irc: Irc | AsyncIrc, line: string): IrcEvent =
   if line.len == 0:
     irc.close()
-    result.typ = EvDisconnected
+    result = IrcEvent(typ: EvDisconnected)
   else:
     result = parseMessage(line)
     
@@ -363,7 +363,7 @@ proc processLine(irc: Irc | AsyncIrc, line: string): IrcEvent =
 
     if result.cmd == MError:
       irc.close()
-      result.typ = EvDisconnected
+      result = IrcEvent(typ: EvDisconnected)
       return
 
     if result.cmd == MPong:


### PR DESCRIPTION
This fixes two `result.typ = ...` issues, which I missed with the last go-around because I only looked for `ev.typ`. This also changes like 210-214 to reflect the new style and avoid doing `.typ = ...` altogether as much as possible, though if you feel this is an overly defensive change, feel free to revert it.

Version has also been bumped to 0.2.2, although I'm almost tempted to bump it up to 0.3 given the past few commits have been pretty big bugfixes. /shrug