### PR TITLE
Added a `text` property to IrcEvent.

### DIFF
--- a/src/irc.nim
+++ b/src/irc.nim
@@ -105,6 +105,7 @@ type
       params*: seq[string]  ## Parameters of the IRC message
       origin*: string       ## The channel/user that this msg originated from
       raw*: string          ## Raw IRC message
+      text*: string         ## Text intended for the recipient (the last value in params).
       timestamp*: Time      ## UNIX epoch time the message was received
 
   Info = enum
@@ -293,6 +294,9 @@ proc parseMessage(msg: string): IrcEvent =
   if i < msg.len and msg[i] == ':':
     inc(i) # Skip `:`.
     result.params.add(msg[i..msg.len-1])
+
+  if result.params.len > 0:
+    result.text = result.params[^1]
 
 proc connect*(irc: Irc) =
   ## Connects to an IRC server as specified by ``irc``.

--- a/src/irc.nim
+++ b/src/irc.nim
@@ -12,17 +12,19 @@
 ##
 ## .. code-block:: Nim
 ##
-##   var client = irc("picheta.me", joinChans = @["#bots"])
+##   let client = newIrc("picheta.me", joinChans = @["#bots"])
 ##   client.connect()
 ##   while True:
 ##     var event: IrcEvent
 ##     if client.poll(event):
 ##       case event.typ
-##       of EvConnected: nil
+##       of EvConnected: discard
 ##       of EvDisconnected:
 ##         client.reconnect()
 ##       of EvMsg:
 ##         # Write your message reading code here.
+##         echo event.raw
+##      else: discard
 ##
 ## **Warning:** The API of this module is unstable, and therefore is subject
 ## to change.


### PR DESCRIPTION
The `text` property is the last element of `IrcEvent`'s `params` seq.

This is equivalent to the message that would be sent in an IRC channel, or private message.

---

I also updated the docs to be a working example.